### PR TITLE
just forward to `copy` when possible

### DIFF
--- a/src/Collects.jl
+++ b/src/Collects.jl
@@ -213,6 +213,9 @@ module Collects
         end
     end
 
+    Base.@constprop :aggressive function collect_as_set_with_known_eltype(::Type{T}, collection::Set{T}) where {T}
+        copy(collection)
+    end
     Base.@constprop :aggressive function collect_as_set_with_known_eltype(::Type{T}, collection) where {T}
         ret = Set{T}()
         foreach(Base.Fix1(push!, ret), collection)
@@ -274,7 +277,9 @@ module Collects
 
     Base.@constprop :aggressive function collect_as_array_with_known_eltype(::Type{T}, ndims::Int, collection) where {T}
         ndims = check_ndims_consistency(ndims, collection)
-        if iszero(ndims)
+        if collection isa Array{T, ndims}
+            copy(collection)
+        elseif iszero(ndims)
             let e = only(collection)
                 ret = Array{T, 0}(undef)
                 ret[] = e
@@ -333,6 +338,9 @@ module Collects
     end
 
     if optional_memory !== ()
+        Base.@constprop :aggressive function collect_as_memory_with_known_eltype_and_known_length(::Type{T}, collection::Memory{T}) where {T}
+            copy(collection)
+        end
         Base.@constprop :aggressive function collect_as_memory_with_known_eltype_and_known_length(::Type{T}, collection) where {T}
             collect_as_vectorlike_with_known_eltype_and_length(Memory{T}, collection)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ using Test
     end
 
     @testset "`Set`" begin
+        @test Set((1, 2)) == (@inferred collect_as(Set{Int}, Set{Int}((1, 2))))::Set{Int}
+        @test Set((1, 2)) == (@inferred collect_as(Set{Int}, Set{Float32}((1, 2))))::Set{Int}
         @test Set((1, 2)) == (@inferred collect_as(Set, [1, 1, 2]))::Set{Int}
         @test Set((1, 2)) == (@inferred collect_as(Set{Int}, Float32[1, 1, 2]))::Set{Int}
         @test_throws ArgumentError collect_as(Set, Iterators.map((x -> 3 * x), Number[]))
@@ -37,11 +39,19 @@ using Test
 
     @testset "`Array`" begin
         @testset "0D" begin
+            @test fill(3) == (@inferred collect_as(Array{Int}, fill(3)))::Array{Int, 0}
+            @test fill(3) == (@inferred collect_as(Array{Int, 0}, fill(3)))::Array{Int, 0}
+            @test fill(3) == (@inferred collect_as(Array{Int}, fill(3.0)))::Array{Int, 0}
+            @test fill(3) == (@inferred collect_as(Array{Int, 0}, fill(3.0)))::Array{Int, 0}
             @test fill(3) == (@inferred collect_as(Array{<:Any, 0}, 3))::Array{Int, 0}
             @test fill(3) == (@inferred collect_as(Array{Float32, 0}, 3))::Array{Float32, 0}
             @test fill(9) == (@inferred collect_as(Array{<:Any, 0}, Iterators.map((x -> 3 * x), 3)))::Array{Int, 0}
         end
         @testset "1D" begin
+            @test [3] == (@inferred collect_as(Array{Int}, [3]))::Vector{Int}
+            @test [3] == (@inferred collect_as(Vector{Int}, [3]))::Vector{Int}
+            @test [3] == (@inferred collect_as(Array{Int}, Float32[3]))::Vector{Int}
+            @test [3] == (@inferred collect_as(Vector{Int}, Float32[3]))::Vector{Int}
             @test [9] == (@inferred collect_as(Vector, Iterators.map((x -> 3 * x), 3)))::Vector{Int}
             @test [1, 3] == (@inferred collect_as(Array, Iterators.filter(isodd, 1:4)))::Vector{Int}
             @test [1, 3] == (@inferred collect_as(Array{Int}, Iterators.map(Float32, Iterators.filter(isodd, 1:4))))::Vector{Int}
@@ -57,6 +67,8 @@ using Test
 
     (@isdefined Memory) &&
     @testset "`Memory`" begin
+        @test [1, 2] == (@inferred collect_as(Memory{Int}, Memory{Int}([1, 2])))::Memory{Int}
+        @test [1, 2] == (@inferred collect_as(Memory{Int}, Memory{Float32}([1, 2])))::Memory{Int}
         @test [1, 2, 3] == (@inferred collect_as(Memory, [1, 2, 3]))::Memory{Int}
         @test [2, 4, 6] == (@inferred collect_as(Memory, Iterators.map((x -> 2 * x), (1, 2, 3))))::Memory{Int}
         @test [1, 2, 3] == (@inferred collect_as(Memory{Int}, Float32[1, 2, 3]))::Memory{Int}


### PR DESCRIPTION
* For `Set`: greatly improves performance

* For `Vector` and `Memory`: slightly improves effect inference, allowing `nothrow` to be inferred